### PR TITLE
fix question routing on right sidebar

### DIFF
--- a/components/shared/sidebar/RightSidebar.tsx
+++ b/components/shared/sidebar/RightSidebar.tsx
@@ -7,7 +7,7 @@ import { getTopPopularTags } from "@/lib/actions/tag.actions";
 
 const QuestionLink = ({ _id, title }: { _id: string; title: string }) => {
   return (
-    <Link href={`/questions/${_id}`} className="flex-between gap-7">
+    <Link href={`/question/${_id}`} className="flex-between gap-7">
       <p className="body-medium text-dark500_light700">{title}</p>
       <Image
         src="/assets/icons/chevron-right.svg"


### PR DESCRIPTION
fix question routing on right sidebar for hot questions so that it does not link to a non-existent route